### PR TITLE
#7 Re-add wunderio/ddev-wunderio-drupal back if global files are missing

### DIFF
--- a/config.wunderio.yaml
+++ b/config.wunderio.yaml
@@ -4,7 +4,7 @@ hooks:
     # Install the wunderio/ddev-wunderio-drupal add-on if it's not already
     # installed. Developers don't need to do this manually. They just need to
     # clone the project and run ddev start.
-    - exec-host: 'if [ ! -d "$HOME/.ddev/wunderio" ]; then ddev add-on get wunderio/ddev-wunderio-drupal; fi'
+    - exec-host: 'if [ ! -d "$HOME/.ddev/wunderio/core" ]; then ddev add-on get wunderio/ddev-wunderio-drupal; fi'
   post-import-db:
     - exec: "$WUNDERIO_GLOBAL_CACHE_WUNDERIO/core/_run-scripts.sh hooks-db-post-import.sh"
   post-restore-snapshot:


### PR DESCRIPTION
## Overview

This pull request makes a minor update to the `config.wunderio.yaml` file, refining the condition for installing the `wunderio/ddev-wunderio-drupal` add-on to check for the presence of the `core` subdirectory. This ensures the add-on is only installed if it hasn't already been set up correctly.

## Testing

git clone -b feature/#7-Fix-automatic-re-install git@github.com:wunderio/ddev-wunderio-drupal.git && ddev add-on get ./ddev-wunderio-drupal

