### PR TITLE
#22 Add also release notes to update message.

### DIFF
--- a/wunderio/core/hooks-host-post-start-update-check.sh
+++ b/wunderio/core/hooks-host-post-start-update-check.sh
@@ -58,12 +58,14 @@ if [ -z "$REMOTE_VERSION" ] || [ "$REMOTE_VERSION" == "null" ]; then
 fi
 
 # 5. Compare Versions
-# Only print the header/footer if we are actually notifying the user
 if [ "$LOCAL_VERSION" != "$REMOTE_VERSION" ]; then
+    RELEASE_URL="https://github.com/$ADDON_NAME/releases"
+
     echo "------------------------------------------------"
     echo "📦 Addon: $ADDON_NAME"
     echo "🏠 Local Version:  $LOCAL_VERSION"
     echo "☁️  Latest Version: $REMOTE_VERSION"
+    echo "🔗 Release Notes:  $RELEASE_URL"
     echo "------------------------------------------------"
     echo "⚠️  UPDATE AVAILABLE!"
     echo "To update, run:"


### PR DESCRIPTION
## Overview

This pull request makes a minor improvement to the update notification script by adding a link to the release notes when a new version is available. This helps users quickly access the latest changes and instructions for the addon.
## Screenshots

<img width="898" height="248" alt="Screenshot 2025-11-21 at 10 26 06" src="https://github.com/user-attachments/assets/3fd8a37b-faa1-43f9-98cd-f83a01aadc52" />


## Testing

1. Clone this PR
```
git clone -b feature/#22-Add-also-release-notes-to-update-message git@github.com:wunderio/ddev-wunderio-drupal.git
```

2. Install older version of the add-on
```
ddev add-on get wunderio/ddev-wunderio-drupal --version 0.1.1
```

3. Run the update check manually and before make sure the update check for today has not been marked/created yet. It's the /tmp/ddev_check_your_username.. file in /tmp folder.
```
rm /tmp/ddev_check_*
ddev-wunderio-drupal/wunderio/core/hooks-host-post-start-update-check.sh
```

4. Update back to latest version
```
ddev add-on get wunderio/ddev-wunderio-drupal 
```