### PR TITLE
#27 Remove LANDO_WEBROOT env variable.

### DIFF
--- a/config.wunderio.yaml
+++ b/config.wunderio.yaml
@@ -22,10 +22,6 @@ hooks:
     # Update check.
     - exec-host: "~/.ddev/wunderio/core/hooks-host-post-start-update-check.sh"
 web_environment:
-# Both this project and wunderio/lando-drupal use the same file
-# at drush/sites/local.site.yml. To make sure that the local alias
-# is working, we need to set the same environment variables here.
-- LANDO_WEBROOT=$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT
 - WUNDERIO_GLOBAL_CACHE_ROOT=/mnt/ddev-global-cache
 - WUNDERIO_GLOBAL_CACHE_WUNDERIO=/mnt/ddev-global-cache/wunderio
 # When Mutagen is enabled (which it is by default in DDEV v1.19+),


### PR DESCRIPTION
## Overview

This pull request makes a minor update to the `config.wunderio.yaml` configuration file by removing the `LANDO_WEBROOT` environment variable setup. This change helps clean up the configuration and removes redundancy related to local environment variables.

As we are moving away from Lando, then we should not have any legacy support for Lando.

## Testing

1. Clone this PR
`git clone -b feature/27-Remove-LANDO_WEBROOT-env-variable git@github.com:wunderio/ddev-wunderio-drupal.git`

2. Install temporarily this version to your project
` ddev add-on get ./ddev-wunderio-drupal && ddev restart`

3. Check that LANDO_WEBROOT env is gone from your .ddev folder

4. Check if you have LANDO_WEBROOT in your codebase. Usually it's in `drush/` folder.

5. Check here for suggestion how to replace it https://github.com/wunderio/ddev-wunderio-drupal/issues/27

6. Revert above changes by downloading latest version:
`ddev add-on get wunderio/ddev-wunderio-drupal `