### PR TITLE
#38: Remove empty web_environment section

### DIFF
--- a/config.wunderio.yaml
+++ b/config.wunderio.yaml
@@ -27,7 +27,6 @@ hooks:
     - exec: "wdr-core hooks db-post-import.sh"
   post-restore-snapshot:
     - exec: "wdr-core hooks db-post-import.sh"
-web_environment:
 # When Mutagen is enabled (which it is by default in DDEV v1.19+),
 # these directories are bind-mounted directly rather than synced via Mutagen
 # This improves performance for large file directories by bypassing Mutagen's


### PR DESCRIPTION
## Overview

This pull request makes a minor update to the `config.wunderio.yaml` file by removing the empty `web_environment` section.



