### PR TITLE
GH-40: Fix auto-install check to detect outdated versions

### DIFF
--- a/config.wunderio.yaml
+++ b/config.wunderio.yaml
@@ -5,7 +5,8 @@ hooks:
     # Developers don't need to do this manually. They just need to clone the
     # project and run ddev start.
     # We check for wdr-core.sh existence (introduced in 0.5.0) to detect if
-    # the add-on is missing or an old version is installed that needs updating.
+    # the add-on is missing or a pre-0.5.0 version is installed. Versions 0.5.0
+    # and later are checked for updates by host-post-start-update-check.sh.
     - exec-host: 'if [ ! -f "${DDEV_GLOBAL_DIR}/wunderio/core/wdr-core.sh" ]; then ddev add-on get wunderio/ddev-wunderio-drupal; fi'
   post-start:
     # Build hook workaround to run composer install on first start.


### PR DESCRIPTION
# Ticket GH-40

## Overview

The auto-install feature in `config.wunderio.yaml` only checked if the add-on directory existed, not whether it was the correct version. This meant users with version 0.4.1 installed wouldn't automatically get updated to 0.5.0+ when they pulled the updated codebase and ran `ddev start`.

This fix updates the pre-start hook to check for the `wdr-core.sh` file (introduced in 0.5.0) instead of just checking directory existence. This ensures:
- First-time installations still work (file doesn't exist → installs)
- Outdated versions (pre-0.5.0) get automatically updated (file doesn't exist → updates)
- Current versions (0.5.0+) are skipped (file exists → no action needed)

## Changes

### Bug Fixes
- da19456 GH-40: Fix auto-install check to detect outdated versions

## Testing

1. Clone this repo
```bash
git clone git@github.com:wunderio/ddev-wunderio-drupal.git
```

2. Checkout older version prior to 0.5.0
```bash
cd ddev-wunderio-drupal
git checkout 0.4.1
```

3. Remove the shared files of wunderio/ddev-wunderio-drupal from your home folder
```bash
rm -rf ~/.ddev/wunderio
```

4. Install the 0.4.1 version
```bash
cd ..
ddev add-on get ./ddev-wunderio-drupal
```

5. Check that core folder exists now:
```bash
ls -la ~/.ddev/wunderio/core
```

6. You should see these files (there's no wdr-core.sh file, there's no hooks or tools folder)
<img width="801" height="284" alt="Screenshot 2026-02-20 at 12 37 33" src="https://github.com/user-attachments/assets/5abe7b2f-bd60-4324-9c9c-0c3ec2453569" />

7. Manually patch your project by updating:
.ddev/config.wunderio.yaml:
Change:
```
#ddev-generated
hooks:
  pre-start:
    # Install the wunderio/ddev-wunderio-drupal add-on if it's not already
    # installed. Developers don't need to do this manually. They just need to
    # clone the project and run ddev start.
    - exec-host: 'if [ ! -d "$HOME/.ddev/wunderio/core" ]; then ddev add-on get wunderio/ddev-wunderio-drupal; fi'
```
 to

``` 
#ddev-generated
 hooks:
  pre-start:
    # Install or update the wunderio/ddev-wunderio-drupal add-on if needed.
    # Developers don't need to do this manually. They just need to clone the
    # project and run ddev start.
    # We check for wdr-core.sh existence (introduced in 0.5.0) to detect if
    # the add-on is missing or an old version is installed that needs updating.
    - exec-host: 'if [ ! -f "${DDEV_GLOBAL_DIR}/wunderio/core/wdr-core.sh" ]; then ddev add-on get wunderio/ddev-wunderio-drupal; fi'
```

8. Restart DDEV
```bash
ddev restart
```

9. As the file ${DDEV_GLOBAL_DIR}/wunderio/core/wdr-core.sh does not yet exist on your system, it'll trigger installation/update of this add-on.

<img width="981" height="665" alt="Screenshot 2026-02-20 at 12 46 26" src="https://github.com/user-attachments/assets/6a33e009-18f6-45cd-92f7-c0c1097834cd" />
