### PR TITLE
Fix PATH override in syncdb command

### DIFF
--- a/commands/host/wunderio-core-syncdb.sh
+++ b/commands/host/wunderio-core-syncdb.sh
@@ -8,6 +8,6 @@
 ## ExecRaw: true
 ## ProjectTypes: drupal9,drupal10,drupal11
 
-export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:$HOME/.ddev/wunderio/core/
+export PATH="$HOME/.ddev/wunderio/core/:$PATH"
 
 wdr-core.sh tooling syncdb.sh "$@"


### PR DESCRIPTION
Overwriting the PATH completely makes the `syncdb` command fail with `~/.ddev/wunderio/core/tooling/syncdb.sh: line 60: ddev: command not found` (Apple silicon Mac, DDEV installed via Homebrew). Let's prepend the wunderio dir to the existing PATH instead.