### PR TITLE
#51: Optimize Mutagen sync by excluding public files

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,37 @@ startup times can be reduced from minutes to seconds.
 **Note for Linux users:** While this configuration doesn't provide performance improvements on Linux
 systems (which don't use Mutagen), it's still good practice to store database dumps in the
 dedicated `database_dumps` folder for consistent organization across team environments.
+
+### Optional Mutagen optimizations for large directories
+
+In many Drupal projects, certain directories can become very large and are generated
+artifacts that do not benefit from being synced via Mutagen.
+
+One common candidate is:
+
+- `../node_modules` at the project root (for front‑end tooling)
+
+If you notice slow DDEV startup or sync performance due to `node_modules`, you can
+optionally add it to `upload_dirs` in your **project’s** `.ddev/config.yaml`
+like this:
+
+```yaml
+upload_dirs:
+  - ../node_modules
+```
+
+This will bind‑mount `../node_modules` instead of syncing it through Mutagen. Because the
+exact directory layout and usage of `node_modules` can vary between projects, this
+template does **not** enable that exclusion by default; add it only if it makes
+sense for your project.
+
+You can also exclude `node_modules` in specific custom themes or modules by adding
+their paths explicitly, for example:
+
+```yaml
+upload_dirs:
+  - web/themes/custom/my_theme/node_modules
+  - web/modules/custom/my_module/node_modules
+```
+
+Adjust the paths to match your actual theme or module names.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ scripts to enhance your Drupal development workflow.
 ### Steps
 
 1. Initialize your Drupal 10 project. Project name parameter is optional, but
-it's advisable to use domain name as your project name as that's used for
-the subdomain of ddev.site eg if project name is example.com, then localhost
-URL will become example.com.ddev.site.
+   it's advisable to use domain name as your project name as that's used for
+   the subdomain of ddev.site eg if project name is example.com, then localhost
+   URL will become example.com.ddev.site.
 
    ```bash
    ddev config --project-type=drupal10 --docroot=web --project-name=example.com

--- a/config.wunderio.yaml
+++ b/config.wunderio.yaml
@@ -37,5 +37,8 @@ hooks:
 # The paths are relative to the project root.
 upload_dirs:
   # Configure database_dumps directory to be bind-mounted directly
-  # instead of being synced via Mutagen for better performance
+  # instead of being synced via Mutagen for better performance.
   - ../database_dumps
+  # Exclude public files directory, which can become very large.
+  - sites/default/files
+


### PR DESCRIPTION
## Overview

Optimize Mutagen sync by excluding public files

We have this in our config https://github.com/wunderio/ddev-wunderio-drupal/blob/main/config.wunderio.yaml#L38 but it actually does not extend the existing config, but overwrites it. So this PR adds back Drupal files.

## Testing

Verify that the path is correct.