### PR TITLE
GH-57: Fail syncdb early when drush sa returns unresolved alias place…

### DIFF
--- a/wunderio/core/tooling/syncdb.sh
+++ b/wunderio/core/tooling/syncdb.sh
@@ -124,7 +124,7 @@ if [[ "$remote_ssh_host" == *'${'* ]]; then
   display_warning_message "Your Drush site alias host still contains template variables."
   display_warning_message "Ensure alias placeholders are resolved before syncdb (e.g. via SiteAliasAlterCommands)."
   display_warning_message "See: https://www.drush.org/13.x/examples/SiteAliasAlterCommands.php/"
-  display_warning_message "For Mearra projects, copy: https://github.com/wunderio/drupal-project/blob/main/drush/Commands/SiltaAliasAlterCommands.php"
+  display_warning_message "For Mearra projects, copy https://github.com/wunderio/drupal-project/blob/main/drush/Commands/SiltaAliasAlterCommands.php to drush/Commands/SiltaAliasAlterCommands.php"
   exit 1
 fi
 

--- a/wunderio/core/tooling/syncdb.sh
+++ b/wunderio/core/tooling/syncdb.sh
@@ -119,6 +119,14 @@ if [[ -z "$remote_ssh_host" || "$remote_ssh_host" == "null" ]]; then
   exit 1
 fi
 
+if [[ "$remote_ssh_host" == *'${'* ]]; then
+  display_error_message "Unresolved placeholders in SSH host for alias '$ALIAS_KEY': $remote_ssh_host"
+  display_warning_message "Drush site aliases still contain \${ENVIRONMENT}, \${REPOSITORY}, or \${PROJECT}."
+  display_warning_message "Ensure drush/Commands/SiltaAliasAlterCommands.php is up to date and run: ddev drush cc drush"
+  display_warning_message "Verify git remote.origin.url is set in the project root."
+  exit 1
+fi
+
 if [[ -z "$remote_ssh_options" || "$remote_ssh_options" == "null" ]]; then
   display_error_message "Missing or invalid SSH options for alias '$ALIAS_KEY'."
   display_warning_message "Check your drush/sites/self.site.yml configuration for the 'ssh.options' field."

--- a/wunderio/core/tooling/syncdb.sh
+++ b/wunderio/core/tooling/syncdb.sh
@@ -120,10 +120,11 @@ if [[ -z "$remote_ssh_host" || "$remote_ssh_host" == "null" ]]; then
 fi
 
 if [[ "$remote_ssh_host" == *'${'* ]]; then
-  display_error_message "Unresolved placeholders in SSH host for alias '$ALIAS_KEY': $remote_ssh_host"
-  display_warning_message "Drush site aliases still contain \${ENVIRONMENT}, \${REPOSITORY}, or \${PROJECT}."
-  display_warning_message "Ensure drush/Commands/SiltaAliasAlterCommands.php is up to date and run: ddev drush cc drush"
-  display_warning_message "Verify git remote.origin.url is set in the project root."
+  display_error_message "Unresolved placeholder(s) in SSH host for alias '$ALIAS_KEY': $remote_ssh_host"
+  display_warning_message "Your Drush site alias host still contains template variables."
+  display_warning_message "Ensure alias placeholders are resolved before syncdb (e.g. via SiteAliasAlterCommands)."
+  display_warning_message "See: https://www.drush.org/13.x/examples/SiteAliasAlterCommands.php/"
+  display_warning_message "For Mearra projects, copy: https://github.com/wunderio/drupal-project/blob/main/drush/Commands/SiltaAliasAlterCommands.php"
   exit 1
 fi
 


### PR DESCRIPTION
## Overview

Fail syncdb early when drush sa returns unresolved alias placeholders.

The fix for resolving alias placeholders: https://github.com/wunderio/drupal-project/pull/465

We should probably also add url from where to get the updated file.

## Screenshots

<img width="829" height="119" alt="Screenshot 2026-06-01 at 14 58 19" src="https://github.com/user-attachments/assets/24e9db07-e11a-4bab-80fd-558239206dd8" />

## Testing

