### PR TITLE
Use sudo to avoid permissions issues on symlinking

### DIFF
--- a/config.wunderio.yaml
+++ b/config.wunderio.yaml
@@ -13,7 +13,7 @@ hooks:
     # @todo We could potentially make this work from recognizing the command.
     - exec: |
         if ! command -v wdr-core &> /dev/null; then
-          ln -s ${HOME}/wunderio/core/wdr-core.sh /usr/local/bin/wdr-core
+          sudo ln -s ${HOME}/wunderio/core/wdr-core.sh /usr/local/bin/wdr-core
         fi
         # Run once start hook if needed
         if [ ! -f "/mnt/wdr-hooks/ddev_web_post_start_once" ]; then

--- a/homeadditions/wunderio/core/wdr-core.sh
+++ b/homeadditions/wunderio/core/wdr-core.sh
@@ -45,6 +45,10 @@ fi
 export PROJECT_ROOT
 
 # Remove the first argument (the method)
+if [[ $# -lt 1 ]]; then
+    display_error_message "Usage: wdr-core [tooling|hooks] script-name"
+    exit 1
+fi
 script_or_hook="$1"
 shift 1
 


### PR DESCRIPTION
## Overview

- For some reason atleast on linux on recent weeks it has been becoming problem that creating symlink for the core script runner is lacking permissions, added sudo have been fixing this

- confirmed with @Zionknight-crypto that it did happen on mac too
