### PR TITLE
#63: Add ddev importdb interactive dump picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ This project uses [ddev-wunderio-drupal](https://github.com/wunderio/ddev-wunder
   ddev syncdb prod --backup --keep-dump # Combine flags
   ```
 
+- `importdb`: Imports a dump from `database_dumps/` via an interactive picker
+  (`fzf` when available, otherwise a numbered menu). Runs the same post-import
+  hooks as `ddev import-db` (sanitize, deploy, uli).
+
+  ```bash
+  ddev importdb                         # Pick a dump interactively
+  ddev importdb cleaned.sql.gz          # Skip picker; import this file
+  ddev importdb --no-deploy             # Skip running drush deploy after import
+  ```
+
 - `yq`: Runs [yq](https://mikefarah.gitbook.io/yq) commands (YAML processor).
   It's available inside DDEV, but we expose it to host because why not :). It's required in syncdb script, but it could prove useful in day to day work.
 
@@ -231,9 +241,17 @@ upload_dirs:
   - ../database_dumps
 ```
 
-`ddev syncdb` uses this directory automatically. For manual imports:
+`ddev syncdb` uses this directory automatically. For local dumps, prefer the interactive picker:
 
 ```bash
+ddev importdb
+```
+
+Or import a specific file directly:
+
+```bash
+ddev importdb my-database-backup.sql.gz
+# equivalent:
 ddev import-db --file=database_dumps/my-database-backup.sql.gz
 ```
 

--- a/commands/host/wunderio-core-importdb.sh
+++ b/commands/host/wunderio-core-importdb.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+
+## Description: Import a local database dump from database_dumps/ (interactive picker).
+## Usage: importdb
+## Example: "ddev importdb" "ddev importdb cleaned.sql.gz" "ddev importdb --no-deploy"
+## ExecRaw: true
+## ProjectTypes: drupal9,drupal10,drupal11
+
+DDEV_GLOBAL="$(ddev version | grep global-ddev-dir | awk '{print $2}')"
+export PATH="${DDEV_GLOBAL}/homeadditions/wunderio/core/${PATH:+:$PATH}"
+
+wdr-core.sh tooling importdb.sh "$@"

--- a/homeadditions/wunderio/core/_helpers.sh
+++ b/homeadditions/wunderio/core/_helpers.sh
@@ -36,3 +36,8 @@ display_warning_message() {
 
     printf "${color_yellow}${message}${color_reset}\n"
 }
+
+# Function to get the absolute path to the database_dumps/ directory.
+get_database_dumps_dir() {
+    echo "${PROJECT_ROOT}/database_dumps"
+}

--- a/homeadditions/wunderio/core/tooling/importdb.sh
+++ b/homeadditions/wunderio/core/tooling/importdb.sh
@@ -15,7 +15,7 @@ fi
 # --- Sourcing Helper Functions ---
 source "$WUNDERIO_GLOBAL_SCRIPT_ROOT/_helpers.sh"
 
-DUMPS_DIR="$PROJECT_ROOT/database_dumps"
+DUMPS_DIR="$(get_database_dumps_dir)"
 NO_DEPLOY=false
 SELECTED_ARG=""
 

--- a/homeadditions/wunderio/core/tooling/importdb.sh
+++ b/homeadditions/wunderio/core/tooling/importdb.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+#ddev-generated
+
+#
+# Import a local database dump from database_dumps/.
+# Interactively picks a file (fzf when available, bash select otherwise).
+#
+
+set -eu
+
+if [[ -n "${WUNDERIO_DEBUG:-}" ]]; then
+    set -x
+fi
+
+# --- Sourcing Helper Functions ---
+source "$WUNDERIO_GLOBAL_SCRIPT_ROOT/_helpers.sh"
+
+DUMPS_DIR="$PROJECT_ROOT/database_dumps"
+NO_DEPLOY=false
+SELECTED_ARG=""
+
+# --- Parse arguments ---
+for arg in "$@"; do
+  case "$arg" in
+    --no-deploy) NO_DEPLOY=true ;;
+    --help|-h)
+      display_status_message "Usage: ddev importdb [file] [--no-deploy]"
+      display_warning_message "  (no args)     Interactively choose a dump from database_dumps/"
+      display_warning_message "  file          Skip picker; use this dump (basename or path under dumps)"
+      display_warning_message "  --no-deploy   Skip running drush deploy after import"
+      exit 0
+      ;;
+    -*)
+      display_error_message "Unknown option: $arg"
+      display_warning_message "Usage: ddev importdb [file] [--no-deploy]"
+      exit 1
+      ;;
+    *)
+      if [[ -n "$SELECTED_ARG" ]]; then
+        display_error_message "Only one dump file argument is allowed."
+        exit 1
+      fi
+      SELECTED_ARG="$arg"
+      ;;
+  esac
+done
+
+# --- Validate dumps directory ---
+if [[ ! -d "$DUMPS_DIR" ]]; then
+  display_error_message "Directory not found: $DUMPS_DIR"
+  display_warning_message "Store dump files in database_dumps/ at the project root, then retry."
+  exit 1
+fi
+
+# Build newest-first list of dump files (basenames). Bash 3 compatible (no mapfile).
+DUMP_FILES=()
+while IFS= read -r path; do
+  [[ -f "$path" ]] || continue
+  DUMP_FILES+=("$(basename "$path")")
+done < <(ls -t "$DUMPS_DIR"/*.sql.gz "$DUMPS_DIR"/*.sql 2>/dev/null || true)
+
+if [[ ${#DUMP_FILES[@]} -eq 0 ]]; then
+  display_error_message "No .sql or .sql.gz dump files found in $DUMPS_DIR"
+  exit 1
+fi
+
+# --- Resolve selected file ---
+chosen=""
+
+if [[ -n "$SELECTED_ARG" ]]; then
+  # Accept basename, relative path under dumps, or absolute path inside dumps.
+  candidate="$SELECTED_ARG"
+  if [[ "$candidate" != /* ]]; then
+    if [[ "$candidate" == database_dumps/* ]]; then
+      candidate="$PROJECT_ROOT/$candidate"
+    else
+      candidate="$DUMPS_DIR/$(basename "$candidate")"
+    fi
+  fi
+
+  if [[ ! -f "$candidate" ]]; then
+    display_error_message "Dump file not found: $SELECTED_ARG"
+    exit 1
+  fi
+
+  dumps_resolved="$(cd "$DUMPS_DIR" && pwd)"
+  resolved="$(cd "$(dirname "$candidate")" && pwd)/$(basename "$candidate")"
+  case "$resolved" in
+    "$dumps_resolved"/*) ;;
+    *)
+      display_error_message "Dump file must be inside database_dumps/: $SELECTED_ARG"
+      exit 1
+      ;;
+  esac
+
+  chosen="$(basename "$candidate")"
+else
+  display_status_message "Select a dump from database_dumps/:"
+
+  if command -v fzf >/dev/null 2>&1; then
+    chosen="$(printf '%s\n' "${DUMP_FILES[@]}" | fzf --height=40% --reverse --prompt='Dump> ')" || true
+    if [[ -z "$chosen" ]]; then
+      display_warning_message "No dump selected. Aborting."
+      exit 1
+    fi
+  else
+    display_warning_message "fzf not found; using numbered menu. Install fzf for fuzzy search."
+    PS3="Enter number (or Ctrl-C to cancel): "
+    select item in "${DUMP_FILES[@]}"; do
+      if [[ -n "${item:-}" ]]; then
+        chosen="$item"
+        break
+      fi
+      display_error_message "Invalid selection."
+    done
+    if [[ -z "$chosen" ]]; then
+      display_warning_message "No dump selected. Aborting."
+      exit 1
+    fi
+  fi
+fi
+
+sql_file="$DUMPS_DIR/$chosen"
+
+display_warning_message "This will overwrite your local database with: $chosen"
+
+# Place marker file in the named volume so the post-import hook can read it.
+if [[ "$NO_DEPLOY" == "true" ]]; then
+  ddev exec sudo touch /mnt/wdr-hooks/.no-deploy
+  trap 'ddev exec sudo rm -f /mnt/wdr-hooks/.no-deploy' EXIT
+fi
+
+display_status_message "Importing $sql_file ..."
+# ddev import-db natively handles .gz files.
+ddev import-db --file="$sql_file"
+
+{ set +x; } 2>/dev/null
+
+display_status_message "Import of '$chosen' complete!"

--- a/homeadditions/wunderio/core/tooling/importdb.sh
+++ b/homeadditions/wunderio/core/tooling/importdb.sh
@@ -74,7 +74,7 @@ if [[ -n "$SELECTED_ARG" ]]; then
     if [[ "$candidate" == database_dumps/* ]]; then
       candidate="$PROJECT_ROOT/$candidate"
     else
-      candidate="$DUMPS_DIR/$(basename "$candidate")"
+      candidate="$DUMPS_DIR/$candidate"
     fi
   fi
 
@@ -93,7 +93,8 @@ if [[ -n "$SELECTED_ARG" ]]; then
       ;;
   esac
 
-  chosen="$(basename "$candidate")"
+  # Keep the path relative to database_dumps/ so subdirectories work.
+  chosen="${resolved#$dumps_resolved/}"
 else
   display_status_message "Select a dump from database_dumps/:"
 

--- a/homeadditions/wunderio/core/tooling/syncdb.sh
+++ b/homeadditions/wunderio/core/tooling/syncdb.sh
@@ -81,7 +81,7 @@ fi
 # --- 3. Prepare dumps directory and warn about overwrite ---
 display_warning_message "This will overwrite your local database with data from '$SITE_ALIAS'."
 
-DUMPS_DIR="$PROJECT_ROOT/database_dumps"
+DUMPS_DIR="$(get_database_dumps_dir)"
 
 if [ ! -d "$DUMPS_DIR" ]; then
     mkdir -p "$DUMPS_DIR"


### PR DESCRIPTION
# Ticket [#63](https://github.com/wunderio/ddev-wunderio-drupal/issues/63)

## Overview

Adds `ddev importdb` to interactively pick (using arrow keys and enter) a dump from `database_dumps/` and run `ddev import-db`, so local imports no longer need a hand-typed path. Uses `fzf` when available, otherwise a bash numbered menu. Supports `--no-deploy` like `syncdb`.

## Testing

Environment: local DDEV project with the add-on installed/updated and dumps in `database_dumps/`

Instructions:

- [x] Make sure you have dumps under ddev-wunderio-drupal/ folder
- [x] Install this branch and restart ddev: 
```
git clone -b feature/#63-add-ddev-importdb-interactive-dump-picker-for-database_dumps git@github.com:wunderio/ddev-wunderio-drupal.git && ddev add-on get ./ddev-wunderio-drupal && ddev restart
```
- [x] Run `ddev importdb` and confirm the picker lists `*.sql` / `*.sql.gz` (newest first)
- [x] Select a dump and confirm import runs (`ddev import-db`) and post-import hooks still fire (sqlsan / deploy / uli)
- [x] Run `ddev importdb <filename.sql.gz>` and confirm it skips the picker
- [x] Run `ddev importdb --no-deploy` and confirm deploy is skipped
- [x] With `fzf` unavailable, confirm the bash numbered menu still works
- [x] With an empty or missing `database_dumps/`, confirm a clear error
