### PR TITLE
#63: Add --skip-hooks option to importdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ This project uses [ddev-wunderio-drupal](https://github.com/wunderio/ddev-wunder
   ddev importdb                         # Pick a dump interactively
   ddev importdb cleaned.sql.gz          # Skip picker; import this file
   ddev importdb --no-deploy             # Skip running drush deploy after import
+  ddev importdb --skip-hooks            # Skip all post-import hooks (sanitize and deploy)
   ```
 
 - `yq`: Runs [yq](https://mikefarah.gitbook.io/yq) commands (YAML processor).
@@ -251,6 +252,7 @@ Or import a specific file directly:
 
 ```bash
 ddev importdb my-database-backup.sql.gz
+ddev importdb my-database-backup.sql.gz --skip-hooks
 # equivalent:
 ddev import-db --file=database_dumps/my-database-backup.sql.gz
 ```

--- a/commands/host/wunderio-core-importdb.sh
+++ b/commands/host/wunderio-core-importdb.sh
@@ -4,7 +4,7 @@
 
 ## Description: Import a local database dump from database_dumps/ (interactive picker).
 ## Usage: importdb
-## Example: "ddev importdb" "ddev importdb cleaned.sql.gz" "ddev importdb --no-deploy"
+## Example: "ddev importdb" "ddev importdb cleaned.sql.gz" "ddev importdb --no-deploy" "ddev importdb --skip-hooks"
 ## ExecRaw: true
 ## ProjectTypes: drupal9,drupal10,drupal11
 

--- a/homeadditions/wunderio/core/tooling/importdb.sh
+++ b/homeadditions/wunderio/core/tooling/importdb.sh
@@ -17,22 +17,25 @@ source "$WUNDERIO_GLOBAL_SCRIPT_ROOT/_helpers.sh"
 
 DUMPS_DIR="$(get_database_dumps_dir)"
 NO_DEPLOY=false
+SKIP_HOOKS=false
 SELECTED_ARG=""
 
 # --- Parse arguments ---
 for arg in "$@"; do
   case "$arg" in
     --no-deploy) NO_DEPLOY=true ;;
+    --skip-hooks) SKIP_HOOKS=true ;;
     --help|-h)
-      display_status_message "Usage: ddev importdb [file] [--no-deploy]"
+      display_status_message "Usage: ddev importdb [file] [--no-deploy] [--skip-hooks]"
       display_warning_message "  (no args)     Interactively choose a dump from database_dumps/"
       display_warning_message "  file          Skip picker; use this dump (basename or path under dumps)"
       display_warning_message "  --no-deploy   Skip running drush deploy after import"
+      display_warning_message "  --skip-hooks  Skip all post-import hooks (sanitization and deploy)"
       exit 0
       ;;
     -*)
       display_error_message "Unknown option: $arg"
-      display_warning_message "Usage: ddev importdb [file] [--no-deploy]"
+      display_warning_message "Usage: ddev importdb [file] [--no-deploy] [--skip-hooks]"
       exit 1
       ;;
     *)
@@ -126,14 +129,18 @@ sql_file="$DUMPS_DIR/$chosen"
 display_warning_message "This will overwrite your local database with: $chosen"
 
 # Place marker file in the named volume so the post-import hook can read it.
-if [[ "$NO_DEPLOY" == "true" ]]; then
+if [[ "$NO_DEPLOY" == "true" && "$SKIP_HOOKS" != "true" ]]; then
   ddev exec sudo touch /mnt/wdr-hooks/.no-deploy
   trap 'ddev exec sudo rm -f /mnt/wdr-hooks/.no-deploy' EXIT
 fi
 
 display_status_message "Importing $sql_file ..."
 # ddev import-db natively handles .gz files.
-ddev import-db --file="$sql_file"
+import_db_args=(--file="$sql_file")
+if [[ "$SKIP_HOOKS" == "true" ]]; then
+  import_db_args+=(--skip-hooks)
+fi
+ddev import-db "${import_db_args[@]}"
 
 { set +x; } 2>/dev/null
 


### PR DESCRIPTION
## Overview

This pull request adds support for a new `--skip-hooks` option to the `ddev importdb` command, allowing users to skip all post-import hooks (such as sanitization and deploy steps) when importing a database dump. The documentation and help messages have also been updated to reflect this new option.

## Testing

Environment: local DDEV project with the add-on installed/updated and dumps in `database_dumps/`

Instructions:

- [x] Make sure you have dumps under ddev-wunderio-drupal/ folder
- [x] Install this branch and restart ddev: 
```
git clone -b feature/#63-add-ddev-importdb-interactive-dump-picker-for-database_dumps-v2 git@github.com:wunderio/ddev-wunderio-drupal.git && ddev add-on get ./ddev-wunderio-drupal && ddev restart
```
- [x] Run `ddev importdb` and confirm the picker lists `*.sql` / `*.sql.gz` (newest first)
- [x] Select a dump and confirm import runs (`ddev import-db`) and post-import hooks still fire (sqlsan / deploy / uli)
- [x] Run `ddev importdb <filename.sql.gz>` and confirm it skips the picker
- [x] Run `ddev importdb --no-deploy` and confirm deploy is skipped
- [x] Run `ddev importdb --skip-hooks` and confirm deploy is skipped
- [x] With `fzf` unavailable, confirm the bash numbered menu still works
- [x] With an empty or missing `database_dumps/`, confirm a clear error

