### PR TITLE
#66: Restore GrumPHP EXEC_GRUMPHP_COMMAND instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,15 @@ scripts to enhance your Drupal development workflow.
    ddev add-on get wunderio/ddev-wunderio-drupal && ddev restart
    ```
 
-3. Optionally if you have GrumPHP installed:
+3. Optionally if you have GrumPHP installed, add this to `grumphp.yml` so git hooks run GrumPHP inside DDEV (git hooks execute on the host, where PHP is often unavailable):
 
-   - **Default setup (recommended):** In many setups the default `php` used by GrumPHP works out of the box and you **do not need any custom `EXEC_GRUMPHP_COMMAND`** in `grumphp.yml`.
-   - **If you previously added a custom `EXEC_GRUMPHP_COMMAND` for DDEV/Lando:** You can safely remove the entire `git_hook_variables` section from `grumphp.yml` and then re‑initialise the hooks so they use the default configuration.
+   ```yaml
+   grumphp:
+     git_hook_variables:
+       EXEC_GRUMPHP_COMMAND: ddev php
+   ```
 
-   After adjusting `grumphp.yml`, re‑init the hook:
+   Then re-init the hooks:
 
    ```bash
    ddev grumphp git:init


### PR DESCRIPTION
## Overview

This pull request updates the documentation for integrating GrumPHP with DDEV in the `README.md` file. The main change is clarifying how to configure GrumPHP to run inside DDEV when using git hooks, and providing a sample configuration snippet for `grumphp.yml`.

Without configuring `grumphp.yml` properly, the .git/hooks/commit-msg is configured to use native host php and that is not what we want as host either does not have PHP or it might be wrong version.

wrong .git/hooks/commit-msg example (last line):
```
(cd "./" && printf "%s\n" "${DIFF}" | exec 'vendor/bin/grumphp' 'git:commit-msg' "--git-user='$GIT_USER'" "--git-email='$GIT_EMAIL'" "$COMMIT_MSG_FILE")
```

## Testing

Verify readme looks correct https://github.com/wunderio/ddev-wunderio-drupal/blob/3fda513cd935fc00148160e556c4cd662ab38231/README.md
